### PR TITLE
Add Invoice service with SQL Server connection

### DIFF
--- a/Services/Invoice/Invoice.API/Controllers/InvoicesController.cs
+++ b/Services/Invoice/Invoice.API/Controllers/InvoicesController.cs
@@ -1,0 +1,25 @@
+using System.Collections.Generic;
+using System.Linq;
+using Invoice.Core.Entities;
+using Invoice.Infrastructure.Data;
+using Microsoft.AspNetCore.Mvc;
+
+namespace Invoice.API.Controllers;
+
+[ApiController]
+[Route("api/v1/[controller]")]
+public class InvoicesController : ControllerBase
+{
+    private readonly InvoiceContext _context;
+
+    public InvoicesController(InvoiceContext context)
+    {
+        _context = context;
+    }
+
+    [HttpGet]
+    public ActionResult<IEnumerable<InvoiceRecord>> Get()
+    {
+        return Ok(_context.Invoices.ToList());
+    }
+}

--- a/Services/Invoice/Invoice.API/Invoice.API.csproj
+++ b/Services/Invoice/Invoice.API/Invoice.API.csproj
@@ -1,0 +1,18 @@
+<Project Sdk="Microsoft.NET.Sdk.Web">
+  <PropertyGroup>
+    <TargetFramework>net6.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+  </PropertyGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\Invoice.Application\Invoice.Application.csproj" />
+    <ProjectReference Include="..\Invoice.Infrastructure\Invoice.Infrastructure.csproj" />
+  </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="6.0.13">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+    <PackageReference Include="Swashbuckle.AspNetCore" Version="6.5.0" />
+  </ItemGroup>
+</Project>

--- a/Services/Invoice/Invoice.API/Program.cs
+++ b/Services/Invoice/Invoice.API/Program.cs
@@ -1,0 +1,22 @@
+using Invoice.Application.Extensions;
+using Invoice.Infrastructure.Extensions;
+
+var builder = WebApplication.CreateBuilder(args);
+
+builder.Services.AddControllers();
+builder.Services.AddApplicationServices();
+builder.Services.AddInfrastructureServices(builder.Configuration);
+builder.Services.AddEndpointsApiExplorer();
+builder.Services.AddSwaggerGen();
+
+var app = builder.Build();
+
+if (app.Environment.IsDevelopment())
+{
+    app.UseSwagger();
+    app.UseSwaggerUI();
+}
+
+app.MapControllers();
+
+app.Run();

--- a/Services/Invoice/Invoice.API/appsettings.json
+++ b/Services/Invoice/Invoice.API/appsettings.json
@@ -1,0 +1,6 @@
+{
+  "ConnectionStrings": {
+    "InvoiceConnectionString": "Server=(localdb)\\MSSQLLocalDB;Database=InvoiceDB;Trusted_Connection=True;"
+  },
+  "AllowedHosts": "*"
+}

--- a/Services/Invoice/Invoice.Application/Extensions/ApplicationServiceRegistration.cs
+++ b/Services/Invoice/Invoice.Application/Extensions/ApplicationServiceRegistration.cs
@@ -1,0 +1,11 @@
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Invoice.Application.Extensions;
+
+public static class ApplicationServiceRegistration
+{
+    public static IServiceCollection AddApplicationServices(this IServiceCollection services)
+    {
+        return services;
+    }
+}

--- a/Services/Invoice/Invoice.Application/Invoice.Application.csproj
+++ b/Services/Invoice/Invoice.Application/Invoice.Application.csproj
@@ -1,0 +1,10 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net6.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\Invoice.Core\Invoice.Core.csproj" />
+  </ItemGroup>
+</Project>

--- a/Services/Invoice/Invoice.Core/Common/EntityBase.cs
+++ b/Services/Invoice/Invoice.Core/Common/EntityBase.cs
@@ -1,0 +1,10 @@
+namespace Invoice.Core.Common;
+
+public abstract class EntityBase
+{
+    public int Id { get; protected set; }
+    public string? CreatedBy { get; set; }
+    public DateTime? CreatedDate { get; set; }
+    public string? LastModifiedBy { get; set; }
+    public DateTime? LastModifiedDate { get; set; }
+}

--- a/Services/Invoice/Invoice.Core/Entities/InvoiceRecord.cs
+++ b/Services/Invoice/Invoice.Core/Entities/InvoiceRecord.cs
@@ -1,0 +1,10 @@
+using Invoice.Core.Common;
+
+namespace Invoice.Core.Entities;
+
+public class InvoiceRecord : EntityBase
+{
+    public string? Number { get; set; }
+    public decimal Amount { get; set; }
+    public DateTime InvoiceDate { get; set; }
+}

--- a/Services/Invoice/Invoice.Core/Invoice.Core.csproj
+++ b/Services/Invoice/Invoice.Core/Invoice.Core.csproj
@@ -1,0 +1,7 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net6.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+</Project>

--- a/Services/Invoice/Invoice.Infrastructure/Data/InvoiceContext.cs
+++ b/Services/Invoice/Invoice.Infrastructure/Data/InvoiceContext.cs
@@ -1,0 +1,13 @@
+using Microsoft.EntityFrameworkCore;
+using Invoice.Core.Entities;
+
+namespace Invoice.Infrastructure.Data;
+
+public class InvoiceContext : DbContext
+{
+    public InvoiceContext(DbContextOptions<InvoiceContext> options) : base(options)
+    {
+    }
+
+    public DbSet<InvoiceRecord> Invoices => Set<InvoiceRecord>();
+}

--- a/Services/Invoice/Invoice.Infrastructure/Extensions/InfrastructureServiceRegistration.cs
+++ b/Services/Invoice/Invoice.Infrastructure/Extensions/InfrastructureServiceRegistration.cs
@@ -1,0 +1,16 @@
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Invoice.Infrastructure.Data;
+
+namespace Invoice.Infrastructure.Extensions;
+
+public static class InfrastructureServiceRegistration
+{
+    public static IServiceCollection AddInfrastructureServices(this IServiceCollection services, IConfiguration configuration)
+    {
+        services.AddDbContext<InvoiceContext>(options =>
+            options.UseSqlServer(configuration.GetConnectionString("InvoiceConnectionString")));
+        return services;
+    }
+}

--- a/Services/Invoice/Invoice.Infrastructure/Invoice.Infrastructure.csproj
+++ b/Services/Invoice/Invoice.Infrastructure/Invoice.Infrastructure.csproj
@@ -1,0 +1,14 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net6.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\Invoice.Core\Invoice.Core.csproj" />
+  </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="6.0.13" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="6.0.13" />
+  </ItemGroup>
+</Project>


### PR DESCRIPTION
## Summary
- add Invoice microservice skeleton
- configure SQL Server connection for Invoice service

## Testing
- `dotnet build Services/Invoice/Invoice.API/Invoice.API.csproj` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68b180297ccc832b9b4647571c980ed1